### PR TITLE
Fix admin display issue

### DIFF
--- a/app/code/local/Twocheckout/Api/etc/system.xml
+++ b/app/code/local/Twocheckout/Api/etc/system.xml
@@ -6,7 +6,7 @@
                 <twocheckout translate="label" module="twocheckout">
                     <label>2Checkout API</label>
                     <frontend_type>text</frontend_type>
-                    <sort_order>0</sort_order>
+                    <sort_order>1</sort_order>
                     <show_in_default>1</show_in_default>
                     <show_in_website>1</show_in_website>
                     <show_in_store>1</show_in_store>


### PR DESCRIPTION
The Drop down list of payment methods was not displaying correctly for
the Payment API, overlapping with the "Don't know what paypal to use"
message. Corrected by setting the sort order of the API module to "1"
instead of "0"
