### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,6 @@
 14. Save your changes.
 
 Please feel free to contact 2Checkout directly with any integration questions.
+
+#### Requirements
+PHP 5.4.0 or later.


### PR DESCRIPTION
Added a requirements section to specify that this library requires a PHP version of 5.4.0 or above because of the use of the short array syntax (e.g. $post = []; on line 28 of RedirectController.php). This is important to note because Nexcess, a popular Magento host, still sets up servers with PHP 5.3.24 by default at this time.
